### PR TITLE
`Update assignee logic in HealthAndSafety controllers to use 'Section…

### DIFF
--- a/app/Http/Controllers/HealthAndSaftyControllers/AiAccidentRecordController.php
+++ b/app/Http/Controllers/HealthAndSaftyControllers/AiAccidentRecordController.php
@@ -252,7 +252,7 @@ class AiAccidentRecordController extends Controller
 
         $targetLevel = $user->assigneeLevel + 1;
 
-        $assignees = $this->userInterface->getUsersByAssigneeLevelAndSection($targetLevel, 'Accident')
+        $assignees = $this->userInterface->getUsersByAssigneeLevelAndSection($targetLevel, 'Accident Section')
             ->where('availability', 1);
         return response()->json( $assignees);
     }

--- a/app/Http/Controllers/HealthAndSaftyControllers/AiIncidentRecodeController.php
+++ b/app/Http/Controllers/HealthAndSaftyControllers/AiIncidentRecodeController.php
@@ -243,7 +243,7 @@ class AiIncidentRecodeController extends Controller
 
         $targetLevel = $user->assigneeLevel + 1;
 
-        $assignees = $this->userInterface->getUsersByAssigneeLevelAndSection($targetLevel, 'Incident')
+        $assignees = $this->userInterface->getUsersByAssigneeLevelAndSection($targetLevel, 'Incident Section')
             ->where('availability', 1);
         return response()->json($assignees);
     }

--- a/app/Http/Controllers/HealthAndSaftyControllers/HazardAndRiskController.php
+++ b/app/Http/Controllers/HealthAndSaftyControllers/HazardAndRiskController.php
@@ -194,7 +194,7 @@ class HazardAndRiskController extends Controller
 
         $targetLevel = $user->assigneeLevel + 1;
 
-        $assignees = $this->userInterface->getUsersByAssigneeLevelAndSection($targetLevel, 'Hazard Risk')
+        $assignees = $this->userInterface->getUsersByAssigneeLevelAndSection($targetLevel, 'Hazard And Risk Section')
             ->where('availability', 1);
 
         return response()->json($assignees,);

--- a/app/Http/Controllers/HealthAndSaftyControllers/OsMiMedicineRequestController.php
+++ b/app/Http/Controllers/HealthAndSaftyControllers/OsMiMedicineRequestController.php
@@ -160,7 +160,7 @@ class OsMiMedicineRequestController extends Controller
 
         $targetLevel = $user->assigneeLevel + 1;
 
-        $assignees = $this->userInterface->getUsersByAssigneeLevelAndSection($targetLevel, 'Medicine Request')
+        $assignees = $this->userInterface->getUsersByAssigneeLevelAndSection($targetLevel, 'Medicine Request Section')
             ->where('availability', 1);
 
         return response()->json($assignees);


### PR DESCRIPTION
…' instead of 'Accident', 'Incident', 'Hazard Risk', 'Medicine Request' in getUsersByAssigneeLevelAndSection method calls.`